### PR TITLE
Merging of the dev branch - Includes parallelization of basis and CV optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+tests/__pycache__/*
+.idea/*
+build/*
+dist/*
+src/flexcode.egg-info/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ language: python
 python:
 - '2.7'
 - '3.6'
-install:
-- pip install tox-travis
-- pip install sklearn
-- pip install xgboost
+install: pip install tox-travis
 script: tox
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ language: python
 python:
 - '2.7'
 - '3.6'
-install: pip install tox-travis
+install:
+- pip install tox-travis
+- pip install sklearn
+- pip install xgboost
 script: tox
 deploy:
   provider: pypi

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name = "flexcode",
       packages=["flexcode"],
       install_requires=["numpy", "pywavelets"],
       setup_requires=["pytest-runner"],
-      tests_require=["pytest", "sklearn"],
+      tests_require=["pytest", "sklearn", "xgboost"],
       zip_safe=True,
       extras_require={
           "xgboost" : ["xgboost"],

--- a/src/flexcode/helpers.py
+++ b/src/flexcode/helpers.py
@@ -59,3 +59,20 @@ def params_dict_optim_decision(params, multi_output=False):
 
     return out_param_dict, opt_flag
 
+
+def params_name_format(params, str_rem):
+    '''
+    Changes all the key in dictionaries to remove a specific word from each key (``estimator__``).
+    This is because in order to GridsearchCV on MultiOutputRegressor one needs to
+    use ``estimator__`` in all parameters - but once the best parameters are fetched
+    the name needs to be changed.
+
+    :param params: dictionary of model parameters
+    :param str_rem: word to be removed
+    :returns: dictionary of parameters in which the word has been removed in keys
+    '''
+    out_dict = {}
+    for k, v in params.items():
+        new_key = k.replace(str_rem, '') if str_rem in k else k
+        out_dict[new_key] = v
+    return out_dict

--- a/src/flexcode/helpers.py
+++ b/src/flexcode/helpers.py
@@ -7,7 +7,6 @@ def box_transform(z, z_min, z_max):
     :param z_min: float, the minimum value of the z box
     :param z_max: float, the maximum value of the z box
     :returns: z projected onto [0, 1]
-    :rtype: array
 
     """
 
@@ -20,7 +19,43 @@ def make_grid(n_grid, z_min, z_max):
     :param z_min: float, the minimum value of the z box
     :param z_max: float, the maximum value of the z box
     :returns: a grid of n_grid equally spaced points between z_min and z_max
-    :rtype: array
 
     """
     return np.linspace(z_min, z_max, n_grid).reshape((n_grid, 1))
+
+def params_dict_optim_decision(params, multi_output=False):
+    '''
+    Ingest parameter dictionary and determines whether to do CV optimization.
+    If one of the parameter has a list of length above 1 as values
+    then automatically format the dictionary for GridSearchCV.
+
+    :param params: dictionary of model parameters
+    :param multi_output: boolean flag, whether the optimization would need
+        to be performed in MultiOutputRegressor
+    :returns: a dictionary of parameters and a boolean flag of whether CV-opt
+        is going to be performed. If CV-optimization is set to happen then
+        the paramater dictionary is correctly format.
+    '''
+
+    # Determines whether there are any list in the items of the dictionary
+    opt_flag = False
+    for k, value in params.items():
+        if type(value) == tuple:
+            raise ValueError("Parameter values need to be lists or np.array, not tuple."
+                             "Current issues with parameter %s" % (k))
+        if type(value) == list or type(value) == np.ndarray:
+            opt_flag = True
+            break
+
+    # Format the dictionary if necessary - put int, str and float into a list
+    # with one element
+    out_param_dict = {} if opt_flag else params.copy()
+    if opt_flag:
+        for k, value in params.items():
+            out_value = value.tolist() if type(value) == np.ndarray else value
+            out_value = [out_value] if type(out_value) != list else out_value
+            out_key = 'estimator__' + k if multi_output else k
+            out_param_dict[out_key] = out_value
+
+    return out_param_dict, opt_flag
+

--- a/src/flexcode/regression_models.py
+++ b/src/flexcode/regression_models.py
@@ -97,10 +97,9 @@ class RandomForest(FlexCodeRegression):
             sklearn.ensemble.RandomForestRegressor(), n_jobs=-1
         )
         clf = sklearn.model_selection.GridSearchCV(
-            rf_obj, self.params, cv=5, scoring='neg_mean_squared_error', verbose=2,
-            fit_params={'sample_weight': weight}
+            rf_obj, self.params, cv=5, scoring='neg_mean_squared_error', verbose=2
         )
-        clf.fit(x_train, z_basis)
+        clf.fit(x_train, z_basis, sample_weight=weight)
 
         self.params = params_name_format(clf.best_params_, str_rem='estimator__')
         self.models = sklearn.multioutput.MultiOutputRegressor(
@@ -147,10 +146,9 @@ class XGBoost(FlexCodeRegression):
             xgb.XGBRegressor(), n_jobs=-1
         )
         clf = sklearn.model_selection.GridSearchCV(
-            xgb_obj, self.params, cv=5, scoring='neg_mean_squared_error', verbose=2,
-            fit_params={'sample_weight': weight}
+            xgb_obj, self.params, cv=5, scoring='neg_mean_squared_error', verbose=2
         )
-        clf.fit(x_train, z_basis)
+        clf.fit(x_train, z_basis, sample_weight=weight)
 
         self.params = params_name_format(clf.best_params_, str_rem='estimator__')
         self.models = sklearn.multioutput.MultiOutputRegressor(

--- a/tests/test_cv_optim.py
+++ b/tests/test_cv_optim.py
@@ -1,0 +1,31 @@
+import flexcode
+import numpy as np
+from flexcode.regression_models import NN
+
+def test_coef_predict_same_as_predict():
+    # Generate data p(z | x) = N(x, 1)
+  def generate_data(n_draws):
+    x = np.random.normal(0, 1, n_draws)
+    z = np.random.normal(x, 1, n_draws)
+    return x, z
+
+  x_train, z_train = generate_data(1000)
+  x_validation, z_validation = generate_data(1000)
+  x_test, z_test = generate_data(1000)
+
+  # Parameterize model
+  model = flexcode.FlexCodeModel(NN, max_basis=31, basis_system="cosine",
+                                 regression_params={"k": [5, 10, 20, 25, 30]})
+
+  # Fit and tune model
+  model.fit(x_train, z_train)
+  model.tune(x_validation, z_validation,
+             bump_threshold_grid = np.linspace(0, 0.2, 3),
+             sharpen_grid = np.linspace(0.5, 1.5, 3))
+
+  cdes_predict, z_grid = model.predict(x_test, n_grid=200)
+
+  coefs = model.predict_coefs(x_test)
+  cdes_coefs = coefs.evaluate(z_grid)
+
+  assert np.max(np.abs(cdes_predict - cdes_coefs)) <= 1e-4

--- a/tests/test_cv_optim.py
+++ b/tests/test_cv_optim.py
@@ -1,21 +1,50 @@
 import flexcode
 import numpy as np
-from flexcode.regression_models import NN
+from flexcode.regression_models import NN, RandomForest
 
-def test_coef_predict_same_as_predict():
+def test_coef_predict_same_as_predict_NN():
     # Generate data p(z | x) = N(x, 1)
   def generate_data(n_draws):
     x = np.random.normal(0, 1, n_draws)
     z = np.random.normal(x, 1, n_draws)
     return x, z
 
-  x_train, z_train = generate_data(1000)
-  x_validation, z_validation = generate_data(1000)
-  x_test, z_test = generate_data(1000)
+  x_train, z_train = generate_data(5000)
+  x_validation, z_validation = generate_data(5000)
+  x_test, z_test = generate_data(5000)
 
   # Parameterize model
   model = flexcode.FlexCodeModel(NN, max_basis=31, basis_system="cosine",
                                  regression_params={"k": [5, 10, 20, 25, 30]})
+
+  # Fit and tune model
+  model.fit(x_train, z_train)
+  model.tune(x_validation, z_validation,
+             bump_threshold_grid = np.linspace(0, 0.2, 3),
+             sharpen_grid = np.linspace(0.5, 1.5, 3))
+
+  cdes_predict, z_grid = model.predict(x_test, n_grid=200)
+
+  coefs = model.predict_coefs(x_test)
+  cdes_coefs = coefs.evaluate(z_grid)
+
+  assert np.max(np.abs(cdes_predict - cdes_coefs)) <= 1e-4
+
+
+def test_coef_predict_same_as_predict_RF():
+    # Generate data p(z | x) = N(x, 1)
+  def generate_data(n_draws):
+    x = np.random.normal(0, 1, n_draws)
+    z = np.random.normal(x, 1, n_draws)
+    return x, z
+
+  x_train, z_train = generate_data(5000)
+  x_validation, z_validation = generate_data(5000)
+  x_test, z_test = generate_data(5000)
+
+  # Parameterize model
+  model = flexcode.FlexCodeModel(RandomForest, max_basis=31, basis_system="cosine",
+                                 regression_params={"n_estimators": [10, 20, 30], 'min_samples_split': [2, 5]})
 
   # Fit and tune model
   model.fit(x_train, z_train)

--- a/tests/test_cv_optim.py
+++ b/tests/test_cv_optim.py
@@ -1,6 +1,7 @@
 import flexcode
 import numpy as np
-from flexcode.regression_models import NN, RandomForest
+from flexcode.regression_models import NN, RandomForest, XGBoost
+
 
 def test_coef_predict_same_as_predict_NN():
     # Generate data p(z | x) = N(x, 1)
@@ -45,6 +46,36 @@ def test_coef_predict_same_as_predict_RF():
   # Parameterize model
   model = flexcode.FlexCodeModel(RandomForest, max_basis=31, basis_system="cosine",
                                  regression_params={"n_estimators": [10, 20, 30], 'min_samples_split': [2, 5]})
+
+  # Fit and tune model
+  model.fit(x_train, z_train)
+  model.tune(x_validation, z_validation,
+             bump_threshold_grid = np.linspace(0, 0.2, 3),
+             sharpen_grid = np.linspace(0.5, 1.5, 3))
+
+  cdes_predict, z_grid = model.predict(x_test, n_grid=200)
+
+  coefs = model.predict_coefs(x_test)
+  cdes_coefs = coefs.evaluate(z_grid)
+
+  assert np.max(np.abs(cdes_predict - cdes_coefs)) <= 1e-4
+
+
+def test_coef_predict_same_as_predict_XGB():
+    # Generate data p(z | x) = N(x, 1)
+  def generate_data(n_draws):
+    x = np.random.normal(0, 1, n_draws)
+    z = np.random.normal(x, 1, n_draws)
+    return x, z
+
+  x_train, z_train = generate_data(5000)
+  x_validation, z_validation = generate_data(5000)
+  x_test, z_test = generate_data(5000)
+
+  # Parameterize model
+  model = flexcode.FlexCodeModel(XGBoost, max_basis=31, basis_system="cosine",
+                                 regression_params={"max_depth": [3, 5, 8],
+                                                    'eta': [0.1, 0.2, 0.5]})
 
   # Fit and tune model
   model.fit(x_train, z_train)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,7 +15,7 @@ def test_example():
 
   # Parameterize model
   model = flexcode.FlexCodeModel(NN, max_basis=31, basis_system="cosine",
-                                 regression_params={"k":20})
+                                 regression_params={"k": 20})
 
   # Fit and tune model
   model.fit(x_train, z_train)

--- a/tests/test_params_handling.py
+++ b/tests/test_params_handling.py
@@ -1,0 +1,75 @@
+import pytest
+import numpy as np
+from flexcode.helpers import params_dict_optim_decision
+
+def test_params_transform():
+
+    dict1 = {'k': [1, 2, 3, 4, 5, 6]}
+    dictout1a, flag1a = params_dict_optim_decision(dict1)
+
+    assert dictout1a == dict1
+    assert flag1a == True
+
+    dictout1b, flag1b = params_dict_optim_decision(dict1, True)
+    assert dictout1b == {'estimator__k': [1, 2, 3, 4, 5, 6]}
+    assert flag1b == True
+
+    ############################################################
+
+    dict2 = {'k': 1}
+    dictout2a, flag2a = params_dict_optim_decision(dict2)
+
+    assert dictout2a == dict2
+    assert flag2a == False
+
+    dictout2b, flag2b = params_dict_optim_decision(dict2, True)
+    assert dictout2b == dict2
+    assert flag2b == False
+
+    #############################################################
+
+    dict3 = {'k': [1, 2, 3, 4, 5, 6], 'obj': 'linear', 'eta': 0.3}
+    dictout3a, flag3a = params_dict_optim_decision(dict3)
+
+    assert dictout3a == {'k': [1, 2, 3, 4, 5, 6], 'obj': ['linear'], 'eta': [0.3]}
+    assert flag3a == True
+
+    dictout3b, flag3b = params_dict_optim_decision(dict3, True)
+    assert dictout3b == {'estimator__k': [1, 2, 3, 4, 5, 6],
+                         'estimator__obj': ['linear'],
+                         'estimator__eta': [0.3]}
+    assert flag3b == True
+
+    ############################################################
+
+    dict4 = {'k': 1, 'obj': 'linear', 'eta': 0.3}
+    dictout4a, flag4a = params_dict_optim_decision(dict4)
+
+    assert dictout4a == dict4
+    assert flag4a == False
+
+    dictout4b, flag4b = params_dict_optim_decision(dict4, True)
+    assert dictout4b == dict4
+    assert flag4b == False
+
+    ############################################################
+
+    dict5 = {'k': (1, 2, 3)}
+    with pytest.raises(Exception):
+        _ = params_dict_optim_decision(dict5)
+
+    #############################################################
+
+    dict6 = {'k': [1, 2, 3, 4, 5, 6], 'obj': 'linear',
+             'eta': np.linspace(0.3, 0.5, 3)}
+    dictout6a, flag6a = params_dict_optim_decision(dict6)
+
+    assert dictout6a == {'k': [1, 2, 3, 4, 5, 6], 'obj': ['linear'],
+                         'eta': [0.3, 0.4, 0.5]}
+    assert flag6a == True
+
+    dictout6b, flag6b = params_dict_optim_decision(dict6, True)
+    assert dictout6b == {'estimator__k': [1, 2, 3, 4, 5, 6],
+                         'estimator__obj': ['linear'],
+                         'estimator__eta': [0.3, 0.4, 0.5]}
+    assert flag6b == True

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,5 @@ deps =
   pytest
   scikit-learn
   scipy
+  xgboost
 commands = pytest --basetemp={envtmpdir} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,5 @@ deps =
   pytest
   scikit-learn
   scipy
-  xgboost
+  xgboost==0.82
 commands = pytest --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
This pull requests merges the following features:

- NN has been moved from `sklearn.neighbors.NearestNeighbors` to `sklearn.neighbors.KNeighborsRegressor`, which allows to leverage the full scikit framework, making it easier to parallelize, optimize parameters and potential work with weights as well;
- Both NN, RF and XGBoost now calculate the basis coefficients in parallel. The base estimator is wrapped around `sklearn.multioutput.MultiOutputRegressor`, which allows for parallelization within the scikit framework;
- Cross-Validation of NN, RF and XGBoost is available now. By passing a list or numpy.ndarray as values in the regression parameters dictionary the `sklearn.model_selection.GridSearchCV` is automatically called with a 5 fold CV. (Potential expansion: allow the user to decide the number of folds and decide to potentially reduce the number of samples used for cross-validation if the training set is too large).